### PR TITLE
Fix TypeScript setup and search navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,7 +20,7 @@ export function Layout({
   let pathname = usePathname()
 
   return (
-    <SectionProvider sections={allSections[pathname] ?? []}>
+    <SectionProvider sections={allSections[pathname ?? ''] ?? []}>
       <div className="h-full lg:ml-72 xl:ml-80">
         <motion.header
           layoutScroll

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -177,18 +177,24 @@ function NavigationGroup({
       </motion.h2>
       <div className="relative mt-3 pl-2">
         <AnimatePresence initial={!isInsideMobileNavigation}>
-          {isActiveGroup && (
-            <VisibleSectionHighlight group={group} pathname={pathname} />
-          )}
+            {isActiveGroup && (
+              <VisibleSectionHighlight
+                group={group}
+                pathname={pathname || ''}
+              />
+            )}
         </AnimatePresence>
         <motion.div
           layout
           className="absolute inset-y-0 left-2 w-px bg-zinc-900/10 dark:bg-white/5"
         />
         <AnimatePresence initial={false}>
-          {isActiveGroup && (
-            <ActivePageMarker group={group} pathname={pathname} />
-          )}
+            {isActiveGroup && (
+              <ActivePageMarker
+                group={group}
+                pathname={pathname || ''}
+              />
+            )}
         </AnimatePresence>
         <ul role="list" className="border-l border-transparent">
           {group.links.map((link) => (


### PR DESCRIPTION
## Summary
- restore `next-env.d.ts` and stop ignoring it
- handle possible null pathnames in Layout and Navigation

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684766e02b94832987ea96c3c6a87c42